### PR TITLE
Remove version-specific download URL from WhatRoute download recipe

### DIFF
--- a/WhatRoute/WhatRoute.download.recipe
+++ b/WhatRoute/WhatRoute.download.recipe
@@ -28,9 +28,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.zip</string>
-				<key>url</key>
-				<string>https://www.whatroute.net/software/whatroute-2.6.9.zip</string>
+				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
The current WhatRoute recipes have a hard-coded download URL, which is contrary to the purpose of AutoPkg. This PR allows SparkleUpdateInfoProvider to provide the download URL for each new version of WhatRoute.

Verbose recipe run output:

```
% autopkg run -vvq 'WhatRoute/WhatRoute.download.recipe'
Processing WhatRoute/WhatRoute.download.recipe...
WARNING: WhatRoute/WhatRoute.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.whatroute.net/whatroute2appcast.xml'}}
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 11990
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.6.9
SparkleUpdateInfoProvider: Found URL https://www.whatroute.net/software/whatroute-2.6.9.zip
{'Output': {'url': 'https://www.whatroute.net/software/whatroute-2.6.9.zip',
            'version': '2.6.9'}}
URLDownloader
{'Input': {'filename': 'WhatRoute-2.6.9.zip',
           'url': 'https://www.whatroute.net/software/whatroute-2.6.9.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 07 May 2024 20:55:03 GMT
URLDownloader: Storing new ETag header: "2408c5e-617e3666aa607"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/downloads/WhatRoute-2.6.9.zip
{'Output': {'download_changed': True,
            'etag': '"2408c5e-617e3666aa607"',
            'last_modified': 'Tue, 07 May 2024 20:55:03 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/downloads/WhatRoute-2.6.9.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/downloads/WhatRoute-2.6.9.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/downloads/WhatRoute-2.6.9.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/WhatRoute',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename WhatRoute-2.6.9.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/downloads/WhatRoute-2.6.9.zip to ~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/WhatRoute
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/WhatRoute/WhatRoute.app',
           'requirement': 'anchor apple generic and identifier '
                          '"net.whatroute.whatroute2" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = H5879E8LML)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/WhatRoute/WhatRoute.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/WhatRoute/WhatRoute.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/WhatRoute/WhatRoute.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/WhatRoute/WhatRoute.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 2.6.9 in file ~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/WhatRoute/WhatRoute.app/Contents/Info.plist
{'Output': {'version': '2.6.9'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/receipts/WhatRoute.download-receipt-20241228-125138.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.gilburns.download.WhatRoute/downloads/WhatRoute-2.6.9.zip
```
