### PR TITLE
Update Hoppscotch Recipes

### DIFF
--- a/Hoppscotch/Hoppscotch.download.recipe
+++ b/Hoppscotch/Hoppscotch.download.recipe
@@ -7,7 +7,7 @@
 	<key>Description</key>
 	<string>Hoppscotch Desktop App is a cross-platform desktop application that helps you create and manage API requests. Downloads the latest version of Hoppscotch.
 
-To download Intel use: "x86" in the ARCHITECTURE and "x86" in DOWNLOAD_ARCH variable (Blank value)
+To download Intel use: "x86_64" in the ARCHITECTURE and "x64" in DOWNLOAD_ARCH variable (Blank value)
 
 To Download Apple Silicon use: "arm64" in the ARCHITECTURE and "aarch64" in DOWNLOAD_ARCH variable (Default value)</string>
 	<key>Identifier</key>
@@ -28,19 +28,10 @@ To Download Apple Silicon use: "arm64" in the ARCHITECTURE and "aarch64" in DOWN
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>asset_regex</key>
-				<string>Hoppscotch_mac_%DOWNLOAD_ARCH%\.dmg</string>
-				<key>github_repo</key>
-				<string>hoppscotch/releases</string>
-			</dict>
-			<key>Processor</key>
-			<string>GitHubReleasesInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
+				<string>%NAME%-%ARCHITECTURE%.dmg</string>
+				<key>url</key>
+				<string>https://github.com/hoppscotch/releases/releases/latest/download/Hoppscotch_mac_%DOWNLOAD_ARCH%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -66,7 +57,7 @@ To Download Apple Silicon use: "arm64" in the ARCHITECTURE and "aarch64" in DOWN
 				<key>input_plist_path</key>
 				<string>%pathname%/Hoppscotch.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
+				<string>CFBundleShortVersionString</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>

--- a/Hoppscotch/Hoppscotch.munki.recipe
+++ b/Hoppscotch/Hoppscotch.munki.recipe
@@ -64,7 +64,7 @@
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 				<key>version_comparison_key</key>
-				<string>CFBundleVersion</string>
+				<string>CFBundleShortVersionString</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>


### PR DESCRIPTION
Hi, @gilburns 

This PR
- Switches to using `CFBundleShortVersionString` for the comparison key and `version`
- Switches to using a static URL as `GitHubReleasesInfoProvider` was having issues picking up what has been tagged as the latest release and would just get whatever was first in the list

Resolves Issue: https://github.com/autopkg/gilburns-recipes/issues/4

Output from -vv runs for x86_64 and arm64
```
autopkg run -vv Hoppscotch.munki.recipe
Looking for com.github.gilburns.download.Hoppscotch...
Did not find com.github.gilburns.download.Hoppscotch in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.gilburns.download.Hoppscotch...
Found com.github.gilburns.download.Hoppscotch in recipe map
**load_recipe time: 0.018742541011306457
Processing Hoppscotch.munki.recipe...
WARNING: Hoppscotch.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Hoppscotch-x86_64.dmg',
           'url': 'https://github.com/hoppscotch/releases/releases/latest/download/Hoppscotch_mac_x64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 06 Mar 2025 12:59:49 GMT
URLDownloader: Storing new ETag header: "0x8DD5CAEC70E7A3C"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-x86_64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD5CAEC70E7A3C"',
            'last_modified': 'Thu, 06 Mar 2025 12:59:49 GMT',
            'pathname': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-x86_64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-x86_64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-x86_64.dmg/Hoppscotch.app',
           'requirement': 'identifier "io.hoppscotch.desktop" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'XBK86CMQGZ'}}
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-x86_64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.1f9LZY/Hoppscotch.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.1f9LZY/Hoppscotch.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.1f9LZY/Hoppscotch.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-x86_64.dmg/Hoppscotch.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-x86_64.dmg
Versioner: Found version 25.2.1 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-x86_64.dmg/Hoppscotch.app/Contents/Info.plist
{'Output': {'version': '25.2.1'}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '25.2.1'},
           'pkginfo': {'catalogs': ['testing'],
                       'category': '',
                       'description': 'Hoppscotch Desktop App releases.',
                       'developer': 'HOPPSCOTCH',
                       'display_name': 'Hoppscotch',
                       'name': 'Hoppscotch',
                       'supported_architectures': ['x86_64'],
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '25.2.1'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'category': '',
                        'description': 'Hoppscotch Desktop App releases.',
                        'developer': 'HOPPSCOTCH',
                        'display_name': 'Hoppscotch',
                        'name': 'Hoppscotch',
                        'supported_architectures': ['x86_64'],
                        'unattended_install': True,
                        'version': '25.2.1'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-x86_64.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': '',
                       'description': 'Hoppscotch Desktop App releases.',
                       'developer': 'HOPPSCOTCH',
                       'display_name': 'Hoppscotch',
                       'name': 'Hoppscotch',
                       'supported_architectures': ['x86_64'],
                       'unattended_install': True,
                       'version': '25.2.1'},
           'repo_subdirectory': 'apps/Hoppscotch',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Hoppscotch/Hoppscotch-25.2.1-x86_64.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Hoppscotch/Hoppscotch-x86_64-25.2.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Hoppscotch',
                                                       'pkg_repo_path': 'apps/Hoppscotch/Hoppscotch-x86_64-25.2.1.dmg',
                                                       'pkginfo_path': 'apps/Hoppscotch/Hoppscotch-25.2.1-x86_64.plist',
                                                       'version': '25.2.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul.cossey',
                                         'creation_date': datetime.datetime(2025, 3, 10, 9, 40, 29),
                                         'munki_version': '6.3.2.4588',
                                         'os_version': '15.4'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': '',
                           'description': 'Hoppscotch Desktop App releases.',
                           'developer': 'HOPPSCOTCH',
                           'display_name': 'Hoppscotch',
                           'installer_item_hash': '1bb1ca7d63013a27d9e2fb996fc789e4f284152b92613ec54d0ba3dc8612b442',
                           'installer_item_location': 'apps/Hoppscotch/Hoppscotch-x86_64-25.2.1.dmg',
                           'installer_item_size': 30087,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'io.hoppscotch.desktop',
                                         'CFBundleName': 'Hoppscotch',
                                         'CFBundleShortVersionString': '25.2.1',
                                         'CFBundleVersion': '20250306.121851',
                                         'minosversion': '10.13',
                                         'path': '/Applications/Hoppscotch.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Hoppscotch.app'}],
                           'minimum_os_version': '10.13',
                           'name': 'Hoppscotch',
                           'supported_architectures': ['x86_64'],
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '25.2.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Hoppscotch/Hoppscotch-x86_64-25.2.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Hoppscotch/Hoppscotch-25.2.1-x86_64.plist'}}
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/receipts/Hoppscotch.munki-receipt-20250310-094029.plist

The following new items were downloaded:
    Download Path                                                                                                  
    -------------                                                                                                  
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-x86_64.dmg  

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                                    Pkg Repo Path                                 Icon Repo Path  
    ----        -------  --------  ------------                                    -------------                                 --------------  
    Hoppscotch  25.2.1   testing   apps/Hoppscotch/Hoppscotch-25.2.1-x86_64.plist  apps/Hoppscotch/Hoppscotch-x86_64-25.2.1.dmg
```

```
autopkg run -vv Hoppscotch.munki.recipe
Looking for com.github.gilburns.download.Hoppscotch...
Did not find com.github.gilburns.download.Hoppscotch in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.gilburns.download.Hoppscotch...
Found com.github.gilburns.download.Hoppscotch in recipe map
**load_recipe time: 0.02104066699394025
Processing Hoppscotch.munki.recipe...
WARNING: Hoppscotch.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Hoppscotch-arm64.dmg',
           'url': 'https://github.com/hoppscotch/releases/releases/latest/download/Hoppscotch_mac_aarch64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 06 Mar 2025 12:59:34 GMT
URLDownloader: Storing new ETag header: "0x8DD5CAEBE911C4B"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-arm64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD5CAEBE911C4B"',
            'last_modified': 'Thu, 06 Mar 2025 12:59:34 GMT',
            'pathname': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-arm64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-arm64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-arm64.dmg/Hoppscotch.app',
           'requirement': 'identifier "io.hoppscotch.desktop" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'XBK86CMQGZ'}}
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-arm64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.dJC5kn/Hoppscotch.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.dJC5kn/Hoppscotch.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.dJC5kn/Hoppscotch.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-arm64.dmg/Hoppscotch.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-arm64.dmg
Versioner: Found version 25.2.1 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-arm64.dmg/Hoppscotch.app/Contents/Info.plist
{'Output': {'version': '25.2.1'}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '25.2.1'},
           'pkginfo': {'catalogs': ['testing'],
                       'category': '',
                       'description': 'Hoppscotch Desktop App releases.',
                       'developer': 'HOPPSCOTCH',
                       'display_name': 'Hoppscotch',
                       'name': 'Hoppscotch',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '25.2.1'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'category': '',
                        'description': 'Hoppscotch Desktop App releases.',
                        'developer': 'HOPPSCOTCH',
                        'display_name': 'Hoppscotch',
                        'name': 'Hoppscotch',
                        'supported_architectures': ['arm64'],
                        'unattended_install': True,
                        'version': '25.2.1'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-arm64.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': '',
                       'description': 'Hoppscotch Desktop App releases.',
                       'developer': 'HOPPSCOTCH',
                       'display_name': 'Hoppscotch',
                       'name': 'Hoppscotch',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True,
                       'version': '25.2.1'},
           'repo_subdirectory': 'apps/Hoppscotch',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Hoppscotch/Hoppscotch-25.2.1-arm64.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Hoppscotch/Hoppscotch-arm64-25.2.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Hoppscotch',
                                                       'pkg_repo_path': 'apps/Hoppscotch/Hoppscotch-arm64-25.2.1.dmg',
                                                       'pkginfo_path': 'apps/Hoppscotch/Hoppscotch-25.2.1-arm64.plist',
                                                       'version': '25.2.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul.cossey',
                                         'creation_date': datetime.datetime(2025, 3, 10, 9, 41),
                                         'munki_version': '6.3.2.4588',
                                         'os_version': '15.4'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': '',
                           'description': 'Hoppscotch Desktop App releases.',
                           'developer': 'HOPPSCOTCH',
                           'display_name': 'Hoppscotch',
                           'installer_item_hash': '2b8929feff4582716163d7e9abc20522b19644f2ba0bd9fe49637a43f1455f38',
                           'installer_item_location': 'apps/Hoppscotch/Hoppscotch-arm64-25.2.1.dmg',
                           'installer_item_size': 29692,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'io.hoppscotch.desktop',
                                         'CFBundleName': 'Hoppscotch',
                                         'CFBundleShortVersionString': '25.2.1',
                                         'CFBundleVersion': '20250306.121517',
                                         'minosversion': '10.13',
                                         'path': '/Applications/Hoppscotch.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Hoppscotch.app'}],
                           'minimum_os_version': '10.13',
                           'name': 'Hoppscotch',
                           'supported_architectures': ['arm64'],
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '25.2.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Hoppscotch/Hoppscotch-arm64-25.2.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Hoppscotch/Hoppscotch-25.2.1-arm64.plist'}}
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/receipts/Hoppscotch.munki-receipt-20250310-094101.plist

The following new items were downloaded:
    Download Path                                                                                                 
    -------------                                                                                                 
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gilburns.munki.Hoppscotch/downloads/Hoppscotch-arm64.dmg  

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                                   Pkg Repo Path                                Icon Repo Path  
    ----        -------  --------  ------------                                   -------------                                --------------  
    Hoppscotch  25.2.1   testing   apps/Hoppscotch/Hoppscotch-25.2.1-arm64.plist  apps/Hoppscotch/Hoppscotch-arm64-25.2.1.dmg
```