### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Loop/Loop.download.recipe
+++ b/Loop/Loop.download.recipe
@@ -40,6 +40,10 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>archive_path</key>
@@ -71,10 +75,6 @@
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/installomator-processor/Installomator.appInDmgInZip.download.recipe
+++ b/installomator-processor/Installomator.appInDmgInZip.download.recipe
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Identifier</key>
@@ -32,6 +34,10 @@
                 <key>filename</key>
                 <string>%name%.zip</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/installomator-processor/Installomator.dmg.download.recipe
+++ b/installomator-processor/Installomator.dmg.download.recipe
@@ -36,6 +36,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>downloaded_file_path</key>

--- a/installomator-processor/Installomator.pkg.download.recipe
+++ b/installomator-processor/Installomator.pkg.download.recipe
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Identifier</key>
@@ -32,6 +34,10 @@
                 <key>filename</key>
                 <string>%name%.pkg</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/installomator-processor/Installomator.pkgInDmg.download.recipe
+++ b/installomator-processor/Installomator.pkgInDmg.download.recipe
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Identifier</key>
@@ -32,6 +34,10 @@
                 <key>filename</key>
                 <string>%name%.dmg</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/installomator-processor/Installomator.pkgInZip.download.recipe
+++ b/installomator-processor/Installomator.pkgInZip.download.recipe
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Identifier</key>
@@ -32,6 +34,10 @@
                 <key>filename</key>
                 <string>%name%.zip</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/installomator-processor/Installomator.tbz.download.recipe
+++ b/installomator-processor/Installomator.tbz.download.recipe
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Identifier</key>
@@ -32,6 +34,10 @@
                 <key>filename</key>
                 <string>%name%.zip</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>

--- a/installomator-processor/Installomator.zip.download.recipe
+++ b/installomator-processor/Installomator.zip.download.recipe
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Identifier</key>
@@ -32,6 +34,10 @@
                 <key>filename</key>
                 <string>%name%.zip</string>
             </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.